### PR TITLE
Fix typo for DJANGO_SETTINGS_MODULE

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ ignore=D,C0111,E501,C0301
 ignore=E501,C0301
 
 [pytest]
-DJANGO_SETTIGNS_MODULE=tests
+DJANGO_SETTINGS_MODULE=tests
 addopts = -sx tests/__init__.py
 
 [testenv]


### PR DESCRIPTION
This may or may not have something to do with CI tests failing.  I'm not familiar with it, but can imagine it could cause an issue somewhere in the process.
